### PR TITLE
FreeDesktop compliant ascii-design.desktop

### DIFF
--- a/icon/ascii-design.desktop
+++ b/icon/ascii-design.desktop
@@ -1,9 +1,11 @@
 [Desktop Entry]
 Encoding=UTF-8
+Version=1.0
 Name=Ascii Design
+GenericName=Ascii art editor
 Comment=Start Ascii Design
 Exec=ascii-design
-Icon=ascii-design.png
+Icon=ascii-design
 Terminal=false
 Type=Application
-Categories=Office;
+Categories=Utility;TextEditor;


### PR DESCRIPTION
@openSUSE is a little strict about this and otherwise aborts builds. I just created an RPM https://build.opensuse.org/request/show/214391 which you can link it via http://software.opensuse.org/package/ascii-design at your homepage.
